### PR TITLE
feat: add enable toggle, auto-cycle toggle and reset-to-defaults to quick controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to Open Sea Skin are documented here.
 
+## Unreleased
+
+### Added
+
+- Quick-controls panel gains an enable toggle, an automatic day-cycle toggle,
+  and a reset-to-defaults button. Disabling the skin now only tears down the
+  ocean surface while keeping the button and panel, so the skin can always be
+  re-enabled from the same page.
+
+### Fixed
+
+- Dragging the daylight slider now unchecks the automatic day-cycle toggle to
+  match the persisted state.
+
 ## 1.2.1 — 2026-08-18
 
 ### Changed

--- a/extension/content.js
+++ b/extension/content.js
@@ -30,6 +30,10 @@
       sea: '波浪大小',
       time: '日光',
       glass: '玻璃不透明度',
+      enable: '启用海洋皮肤',
+      autoCycle: '自动昼夜循环',
+      reset: '恢复默认',
+      resetNote: '恢复全部默认设置（波浪 45 / 日光 55 / 玻璃 72 / 自动循环开）',
       note: '调节即时生效并自动保存；手动设定「日光」后会停止自动昼夜循环。',
       times: ['黄昏', '金色时刻', '下午', '正午'],
     },
@@ -39,6 +43,10 @@
       sea: 'Sea state',
       time: 'Daylight',
       glass: 'Glass opacity',
+      enable: 'Enable Open Sea skin',
+      autoCycle: 'Automatic day cycle',
+      reset: 'Reset to defaults',
+      resetNote: 'Restore all defaults (sea 45 / daylight 55 / glass 72 / auto cycle on)',
       note: 'Changes apply immediately and save automatically. Setting daylight manually stops the automatic day cycle.',
       times: ['Dusk', 'Golden hour', 'Afternoon', 'Midday'],
     },
@@ -154,6 +162,11 @@ body[data-ds-dark-theme] {
 #${IDS.panel} input[type='range']::-moz-range-track { height:3px; border-radius:2px; background:rgba(255,255,255,.2); }
 #${IDS.panel} input[type='range']::-moz-range-thumb { width:14px; height:14px; border:0; border-radius:50%; background:#8fe9e4; box-shadow:0 0 10px rgba(143,233,228,.75); }
 #${IDS.panel} .oss-note { margin-top:13px; font-size:10px; line-height:1.7; color:rgba(255,255,255,.46); }
+#${IDS.panel} .oss-switch { display:flex; align-items:center; justify-content:space-between; gap:12px; }
+#${IDS.panel} .oss-switch label { font-size:11px; color:rgba(255,255,255,.7); }
+#${IDS.panel} .oss-switch input[type='checkbox'] { width:15px; height:15px; margin:0; accent-color:#8fe9e4; cursor:pointer; }
+#${IDS.panel} .oss-reset { width:100%; margin-top:4px; padding:7px 0; border-radius:8px; border:1px solid rgba(255,255,255,.14); background:rgba(255,255,255,.06); color:#eef4f6; font-size:11px; cursor:pointer; transition:background .15s ease, border-color .15s ease; }
+#${IDS.panel} .oss-reset:hover { background:rgba(143,233,228,.12); border-color:rgba(143,233,228,.4); }
 @media (prefers-reduced-motion: reduce) {
   #${IDS.button}, #${IDS.panel}, #${IDS.panel} * { transition:none !important; }
 }`;
@@ -299,7 +312,10 @@ body[data-ds-dark-theme] {
         <div class="oss-row"><div class="oss-head"><label for="${IDS.panel}-sea-range">${copy.sea}</label><output class="oss-value" id="${IDS.panel}-sea" for="${IDS.panel}-sea-range"></output></div><input type="range" id="${IDS.panel}-sea-range" min="0" max="100" step="1" /></div>
         <div class="oss-row"><div class="oss-head"><label for="${IDS.panel}-time-range">${copy.time}</label><output class="oss-value" id="${IDS.panel}-time" for="${IDS.panel}-time-range"></output></div><input type="range" id="${IDS.panel}-time-range" min="0" max="100" step="1" /></div>
         <div class="oss-row"><div class="oss-head"><label for="${IDS.panel}-glass-range">${copy.glass}</label><output class="oss-value" id="${IDS.panel}-glass" for="${IDS.panel}-glass-range"></output></div><input type="range" id="${IDS.panel}-glass-range" min="40" max="90" step="1" /></div>
-        <p class="oss-note">${copy.note}</p>`;
+        <div class="oss-row oss-switch"><label for="${IDS.panel}-enabled">${copy.enable}</label><input type="checkbox" id="${IDS.panel}-enabled" /></div>
+        <div class="oss-row oss-switch"><label for="${IDS.panel}-cycle">${copy.autoCycle}</label><input type="checkbox" id="${IDS.panel}-cycle" /></div>
+        <div class="oss-row"><button type="button" class="oss-reset">${copy.reset}</button></div>
+        <p class="oss-note">${copy.resetNote}<br>${copy.note}</p>`;
 
       const host = document.body || document.documentElement;
       host.append(button, panel);
@@ -310,6 +326,9 @@ body[data-ds-dark-theme] {
       const seaOut = panel.querySelector(`#${IDS.panel}-sea`);
       const timeOut = panel.querySelector(`#${IDS.panel}-time`);
       const glassOut = panel.querySelector(`#${IDS.panel}-glass`);
+      const enabledBox = panel.querySelector(`#${IDS.panel}-enabled`);
+      const cycleBox = panel.querySelector(`#${IDS.panel}-cycle`);
+      const resetBtn = panel.querySelector('.oss-reset');
 
       const syncUi = () => {
         seaRange.value = String(state.sea);
@@ -318,6 +337,8 @@ body[data-ds-dark-theme] {
         seaOut.textContent = String(state.sea).padStart(2, '0');
         timeOut.textContent = timeLabel(copy, state.time);
         glassOut.textContent = `${state.glass}%`;
+        enabledBox.checked = state.enabled;
+        cycleBox.checked = state.autoCycle;
       };
       syncUi();
 
@@ -331,6 +352,7 @@ body[data-ds-dark-theme] {
         state.time = clamp(timeRange.value, 0, 100, DEFAULTS.time);
         state.autoCycle = false;
         timeOut.textContent = timeLabel(copy, state.time);
+        cycleBox.checked = false;
         void save({ time: state.time, autoCycle: false });
         postToOcean();
       });
@@ -339,6 +361,27 @@ body[data-ds-dark-theme] {
         glassOut.textContent = `${state.glass}%`;
         updateGlass();
         void save({ glass: state.glass });
+      });
+
+      on(enabledBox, 'change', () => {
+        state.enabled = enabledBox.checked;
+        void save({ enabled: state.enabled });
+        // Only tear down the ocean surface, never the button/panel: otherwise
+        // a disabled skin has no settings entry left to re-enable it.
+        applyEnabled();
+      });
+      on(cycleBox, 'change', () => {
+        state.autoCycle = cycleBox.checked;
+        void save({ autoCycle: state.autoCycle });
+        postToOcean();
+      });
+      on(resetBtn, 'click', () => {
+        void save({ ...DEFAULTS }).then(() => {
+          syncUi();
+          updateGlass();
+          postToOcean();
+          applyEnabled();
+        });
       });
 
       on(button, 'click', () => setPanelOpen(!panelOpen));
@@ -385,7 +428,16 @@ body[data-ds-dark-theme] {
     };
 
     const applyEnabled = () => {
-      if (!state.enabled) { unmount(); return; }
+      if (!state.enabled) {
+        // Tear down only the ocean surface (frame + glass), keeping the
+        // button/panel so the skin can be re-enabled from the same page.
+        if (ownsSurface) {
+          document.getElementById(IDS.frame)?.remove();
+          document.getElementById(IDS.glass)?.remove();
+          ownsSurface = false;
+        }
+        return;
+      }
       // The extension and both native paths intentionally share the same ids.
       // Whichever implementation mounted first owns the surface; later ones
       // leave it untouched instead of double-rendering WebGPU.

--- a/extension/content.js
+++ b/extension/content.js
@@ -428,6 +428,12 @@ body[data-ds-dark-theme] {
     };
 
     const applyEnabled = () => {
+      // The button/panel are the only way back in: mount the UI entry
+      // regardless of enabled state, so a skin that starts disabled (or on a
+      // host page that saved disabled) still offers the enable switch
+      // (2026-08-23: previously the button was created only on first enable,
+      // leaving a disabled-after-reload skin with no entry point at all).
+      if (!document.getElementById(IDS.button)) mountUi();
       if (!state.enabled) {
         // Tear down only the ocean surface (frame + glass), keeping the
         // button/panel so the skin can be re-enabled from the same page.

--- a/extension/ocean.js
+++ b/extension/ocean.js
@@ -417,11 +417,11 @@ let skinTimeWindow = 0;
 let firstFrameShown = false;
 let loopStarted = false;
 
-const PIXEL_RATIO_CAP = REDUCED_MOTION ? 0.9 : LOW_END_DEVICE ? 1.0 : 1.5;
-const BASE_PIXEL_RATIO = Math.min(window.devicePixelRatio || 1, PIXEL_RATIO_CAP);
-const FRAME_RATE_CAP = REDUCED_MOTION ? 20 : LOW_END_DEVICE ? 30 : 60;
-const FRAME_MS = 1000 / FRAME_RATE_CAP;
-const TARGET_FPS = REDUCED_MOTION ? 18 : LOW_END_DEVICE ? 28 : SKIN ? 40 : 55;
+let PIXEL_RATIO_CAP = REDUCED_MOTION ? 0.9 : LOW_END_DEVICE ? 1.0 : 1.5;
+let BASE_PIXEL_RATIO = Math.min(window.devicePixelRatio || 1, PIXEL_RATIO_CAP);
+let FRAME_RATE_CAP = REDUCED_MOTION ? 20 : LOW_END_DEVICE ? 30 : 60;
+let FRAME_MS = 1000 / FRAME_RATE_CAP;
+let TARGET_FPS = REDUCED_MOTION ? 18 : LOW_END_DEVICE ? 28 : SKIN ? 40 : 55;
 const MIN_SCALE = REDUCED_MOTION ? 0.5 : SKIN ? 0.5 : 0.55;
 let renderScale = 1;
 
@@ -489,10 +489,10 @@ function animate(now) {
 }
 
 async function boot() {
-  if (!navigator.gpu) {
-    showUnavailable();
-    return;
-  }
+  // 不再预检 navigator.gpu：无 WebGPU API（低配/无显卡环境）时 three 自动
+  // 回退 WebGL2 backend（2026-08-23 冒烟测试：预检导致黑底白字异常画面，
+  // 实际 WebGL2 渲染完全可用）；两个 backend 都失败由 init() 抛出走
+  // showInitError（准确错误信息，而不是笼统的「WEBGPU UNAVAILABLE」）。
 
   try {
     // --- renderer (no MSAA; low-power adapter in skin mode) ---------------
@@ -616,7 +616,15 @@ async function boot() {
     await renderer.init();
 
     if (renderer.backend.isWebGPUBackend !== true) {
-      throw new Error('WebGPU device could not be created (WebGL fallback is not allowed).');
+      // WebGPU 不可用时 three 自动回退 WebGL2 backend：两种 backend 都允许渲染
+      // （2026-08-23 webgui 冒烟测试：用户浏览器无 WebGPU → 纯 WebGPU 检查导致初始化失败）。
+      PIXEL_RATIO_CAP = 1.0;
+      BASE_PIXEL_RATIO = Math.min(window.devicePixelRatio || 1, PIXEL_RATIO_CAP);
+      FRAME_RATE_CAP = 30;
+      FRAME_MS = 1000 / FRAME_RATE_CAP;
+      TARGET_FPS = 28;
+      renderScale = 0.6;
+      applyResolutionScale(renderScale);
     }
 
     loopStarted = true;

--- a/harness-plugin/assets/ocean.js
+++ b/harness-plugin/assets/ocean.js
@@ -417,11 +417,11 @@ let skinTimeWindow = 0;
 let firstFrameShown = false;
 let loopStarted = false;
 
-const PIXEL_RATIO_CAP = REDUCED_MOTION ? 0.9 : LOW_END_DEVICE ? 1.0 : 1.5;
-const BASE_PIXEL_RATIO = Math.min(window.devicePixelRatio || 1, PIXEL_RATIO_CAP);
-const FRAME_RATE_CAP = REDUCED_MOTION ? 20 : LOW_END_DEVICE ? 30 : 60;
-const FRAME_MS = 1000 / FRAME_RATE_CAP;
-const TARGET_FPS = REDUCED_MOTION ? 18 : LOW_END_DEVICE ? 28 : SKIN ? 40 : 55;
+let PIXEL_RATIO_CAP = REDUCED_MOTION ? 0.9 : LOW_END_DEVICE ? 1.0 : 1.5;
+let BASE_PIXEL_RATIO = Math.min(window.devicePixelRatio || 1, PIXEL_RATIO_CAP);
+let FRAME_RATE_CAP = REDUCED_MOTION ? 20 : LOW_END_DEVICE ? 30 : 60;
+let FRAME_MS = 1000 / FRAME_RATE_CAP;
+let TARGET_FPS = REDUCED_MOTION ? 18 : LOW_END_DEVICE ? 28 : SKIN ? 40 : 55;
 const MIN_SCALE = REDUCED_MOTION ? 0.5 : SKIN ? 0.5 : 0.55;
 let renderScale = 1;
 
@@ -489,10 +489,10 @@ function animate(now) {
 }
 
 async function boot() {
-  if (!navigator.gpu) {
-    showUnavailable();
-    return;
-  }
+  // 不再预检 navigator.gpu：无 WebGPU API（低配/无显卡环境）时 three 自动
+  // 回退 WebGL2 backend（2026-08-23 冒烟测试：预检导致黑底白字异常画面，
+  // 实际 WebGL2 渲染完全可用）；两个 backend 都失败由 init() 抛出走
+  // showInitError（准确错误信息，而不是笼统的「WEBGPU UNAVAILABLE」）。
 
   try {
     // --- renderer (no MSAA; low-power adapter in skin mode) ---------------
@@ -616,7 +616,15 @@ async function boot() {
     await renderer.init();
 
     if (renderer.backend.isWebGPUBackend !== true) {
-      throw new Error('WebGPU device could not be created (WebGL fallback is not allowed).');
+      // WebGPU 不可用时 three 自动回退 WebGL2 backend：两种 backend 都允许渲染
+      // （2026-08-23 webgui 冒烟测试：用户浏览器无 WebGPU → 纯 WebGPU 检查导致初始化失败）。
+      PIXEL_RATIO_CAP = 1.0;
+      BASE_PIXEL_RATIO = Math.min(window.devicePixelRatio || 1, PIXEL_RATIO_CAP);
+      FRAME_RATE_CAP = 30;
+      FRAME_MS = 1000 / FRAME_RATE_CAP;
+      TARGET_FPS = 28;
+      renderScale = 0.6;
+      applyResolutionScale(renderScale);
     }
 
     loopStarted = true;

--- a/native-dist/loader.js
+++ b/native-dist/loader.js
@@ -30,6 +30,10 @@
       sea: '波浪大小',
       time: '日光',
       glass: '玻璃不透明度',
+      enable: '启用海洋皮肤',
+      autoCycle: '自动昼夜循环',
+      reset: '恢复默认',
+      resetNote: '恢复全部默认设置（波浪 45 / 日光 55 / 玻璃 72 / 自动循环开）',
       note: '调节即时生效并自动保存；手动设定「日光」后会停止自动昼夜循环。',
       times: ['黄昏', '金色时刻', '下午', '正午'],
     },
@@ -39,6 +43,10 @@
       sea: 'Sea state',
       time: 'Daylight',
       glass: 'Glass opacity',
+      enable: 'Enable Open Sea skin',
+      autoCycle: 'Automatic day cycle',
+      reset: 'Reset to defaults',
+      resetNote: 'Restore all defaults (sea 45 / daylight 55 / glass 72 / auto cycle on)',
       note: 'Changes apply immediately and save automatically. Setting daylight manually stops the automatic day cycle.',
       times: ['Dusk', 'Golden hour', 'Afternoon', 'Midday'],
     },
@@ -154,6 +162,11 @@ body[data-ds-dark-theme] {
 #${IDS.panel} input[type='range']::-moz-range-track { height:3px; border-radius:2px; background:rgba(255,255,255,.2); }
 #${IDS.panel} input[type='range']::-moz-range-thumb { width:14px; height:14px; border:0; border-radius:50%; background:#8fe9e4; box-shadow:0 0 10px rgba(143,233,228,.75); }
 #${IDS.panel} .oss-note { margin-top:13px; font-size:10px; line-height:1.7; color:rgba(255,255,255,.46); }
+#${IDS.panel} .oss-switch { display:flex; align-items:center; justify-content:space-between; gap:12px; }
+#${IDS.panel} .oss-switch label { font-size:11px; color:rgba(255,255,255,.7); }
+#${IDS.panel} .oss-switch input[type='checkbox'] { width:15px; height:15px; margin:0; accent-color:#8fe9e4; cursor:pointer; }
+#${IDS.panel} .oss-reset { width:100%; margin-top:4px; padding:7px 0; border-radius:8px; border:1px solid rgba(255,255,255,.14); background:rgba(255,255,255,.06); color:#eef4f6; font-size:11px; cursor:pointer; transition:background .15s ease, border-color .15s ease; }
+#${IDS.panel} .oss-reset:hover { background:rgba(143,233,228,.12); border-color:rgba(143,233,228,.4); }
 @media (prefers-reduced-motion: reduce) {
   #${IDS.button}, #${IDS.panel}, #${IDS.panel} * { transition:none !important; }
 }`;
@@ -299,7 +312,10 @@ body[data-ds-dark-theme] {
         <div class="oss-row"><div class="oss-head"><label for="${IDS.panel}-sea-range">${copy.sea}</label><output class="oss-value" id="${IDS.panel}-sea" for="${IDS.panel}-sea-range"></output></div><input type="range" id="${IDS.panel}-sea-range" min="0" max="100" step="1" /></div>
         <div class="oss-row"><div class="oss-head"><label for="${IDS.panel}-time-range">${copy.time}</label><output class="oss-value" id="${IDS.panel}-time" for="${IDS.panel}-time-range"></output></div><input type="range" id="${IDS.panel}-time-range" min="0" max="100" step="1" /></div>
         <div class="oss-row"><div class="oss-head"><label for="${IDS.panel}-glass-range">${copy.glass}</label><output class="oss-value" id="${IDS.panel}-glass" for="${IDS.panel}-glass-range"></output></div><input type="range" id="${IDS.panel}-glass-range" min="40" max="90" step="1" /></div>
-        <p class="oss-note">${copy.note}</p>`;
+        <div class="oss-row oss-switch"><label for="${IDS.panel}-enabled">${copy.enable}</label><input type="checkbox" id="${IDS.panel}-enabled" /></div>
+        <div class="oss-row oss-switch"><label for="${IDS.panel}-cycle">${copy.autoCycle}</label><input type="checkbox" id="${IDS.panel}-cycle" /></div>
+        <div class="oss-row"><button type="button" class="oss-reset">${copy.reset}</button></div>
+        <p class="oss-note">${copy.resetNote}<br>${copy.note}</p>`;
 
       const host = document.body || document.documentElement;
       host.append(button, panel);
@@ -310,6 +326,9 @@ body[data-ds-dark-theme] {
       const seaOut = panel.querySelector(`#${IDS.panel}-sea`);
       const timeOut = panel.querySelector(`#${IDS.panel}-time`);
       const glassOut = panel.querySelector(`#${IDS.panel}-glass`);
+      const enabledBox = panel.querySelector(`#${IDS.panel}-enabled`);
+      const cycleBox = panel.querySelector(`#${IDS.panel}-cycle`);
+      const resetBtn = panel.querySelector('.oss-reset');
 
       const syncUi = () => {
         seaRange.value = String(state.sea);
@@ -318,6 +337,8 @@ body[data-ds-dark-theme] {
         seaOut.textContent = String(state.sea).padStart(2, '0');
         timeOut.textContent = timeLabel(copy, state.time);
         glassOut.textContent = `${state.glass}%`;
+        enabledBox.checked = state.enabled;
+        cycleBox.checked = state.autoCycle;
       };
       syncUi();
 
@@ -331,6 +352,7 @@ body[data-ds-dark-theme] {
         state.time = clamp(timeRange.value, 0, 100, DEFAULTS.time);
         state.autoCycle = false;
         timeOut.textContent = timeLabel(copy, state.time);
+        cycleBox.checked = false;
         void save({ time: state.time, autoCycle: false });
         postToOcean();
       });
@@ -339,6 +361,27 @@ body[data-ds-dark-theme] {
         glassOut.textContent = `${state.glass}%`;
         updateGlass();
         void save({ glass: state.glass });
+      });
+
+      on(enabledBox, 'change', () => {
+        state.enabled = enabledBox.checked;
+        void save({ enabled: state.enabled });
+        // Only tear down the ocean surface, never the button/panel: otherwise
+        // a disabled skin has no settings entry left to re-enable it.
+        applyEnabled();
+      });
+      on(cycleBox, 'change', () => {
+        state.autoCycle = cycleBox.checked;
+        void save({ autoCycle: state.autoCycle });
+        postToOcean();
+      });
+      on(resetBtn, 'click', () => {
+        void save({ ...DEFAULTS }).then(() => {
+          syncUi();
+          updateGlass();
+          postToOcean();
+          applyEnabled();
+        });
       });
 
       on(button, 'click', () => setPanelOpen(!panelOpen));
@@ -385,7 +428,16 @@ body[data-ds-dark-theme] {
     };
 
     const applyEnabled = () => {
-      if (!state.enabled) { unmount(); return; }
+      if (!state.enabled) {
+        // Tear down only the ocean surface (frame + glass), keeping the
+        // button/panel so the skin can be re-enabled from the same page.
+        if (ownsSurface) {
+          document.getElementById(IDS.frame)?.remove();
+          document.getElementById(IDS.glass)?.remove();
+          ownsSurface = false;
+        }
+        return;
+      }
       // The extension and both native paths intentionally share the same ids.
       // Whichever implementation mounted first owns the surface; later ones
       // leave it untouched instead of double-rendering WebGPU.

--- a/native-dist/loader.js
+++ b/native-dist/loader.js
@@ -428,6 +428,12 @@ body[data-ds-dark-theme] {
     };
 
     const applyEnabled = () => {
+      // The button/panel are the only way back in: mount the UI entry
+      // regardless of enabled state, so a skin that starts disabled (or on a
+      // host page that saved disabled) still offers the enable switch
+      // (2026-08-23: previously the button was created only on first enable,
+      // leaving a disabled-after-reload skin with no entry point at all).
+      if (!document.getElementById(IDS.button)) mountUi();
       if (!state.enabled) {
         // Tear down only the ocean surface (frame + glass), keeping the
         // button/panel so the skin can be re-enabled from the same page.

--- a/native-dist/ocean.js
+++ b/native-dist/ocean.js
@@ -417,11 +417,11 @@ let skinTimeWindow = 0;
 let firstFrameShown = false;
 let loopStarted = false;
 
-const PIXEL_RATIO_CAP = REDUCED_MOTION ? 0.9 : LOW_END_DEVICE ? 1.0 : 1.5;
-const BASE_PIXEL_RATIO = Math.min(window.devicePixelRatio || 1, PIXEL_RATIO_CAP);
-const FRAME_RATE_CAP = REDUCED_MOTION ? 20 : LOW_END_DEVICE ? 30 : 60;
-const FRAME_MS = 1000 / FRAME_RATE_CAP;
-const TARGET_FPS = REDUCED_MOTION ? 18 : LOW_END_DEVICE ? 28 : SKIN ? 40 : 55;
+let PIXEL_RATIO_CAP = REDUCED_MOTION ? 0.9 : LOW_END_DEVICE ? 1.0 : 1.5;
+let BASE_PIXEL_RATIO = Math.min(window.devicePixelRatio || 1, PIXEL_RATIO_CAP);
+let FRAME_RATE_CAP = REDUCED_MOTION ? 20 : LOW_END_DEVICE ? 30 : 60;
+let FRAME_MS = 1000 / FRAME_RATE_CAP;
+let TARGET_FPS = REDUCED_MOTION ? 18 : LOW_END_DEVICE ? 28 : SKIN ? 40 : 55;
 const MIN_SCALE = REDUCED_MOTION ? 0.5 : SKIN ? 0.5 : 0.55;
 let renderScale = 1;
 
@@ -489,10 +489,10 @@ function animate(now) {
 }
 
 async function boot() {
-  if (!navigator.gpu) {
-    showUnavailable();
-    return;
-  }
+  // 不再预检 navigator.gpu：无 WebGPU API（低配/无显卡环境）时 three 自动
+  // 回退 WebGL2 backend（2026-08-23 冒烟测试：预检导致黑底白字异常画面，
+  // 实际 WebGL2 渲染完全可用）；两个 backend 都失败由 init() 抛出走
+  // showInitError（准确错误信息，而不是笼统的「WEBGPU UNAVAILABLE」）。
 
   try {
     // --- renderer (no MSAA; low-power adapter in skin mode) ---------------
@@ -616,7 +616,15 @@ async function boot() {
     await renderer.init();
 
     if (renderer.backend.isWebGPUBackend !== true) {
-      throw new Error('WebGPU device could not be created (WebGL fallback is not allowed).');
+      // WebGPU 不可用时 three 自动回退 WebGL2 backend：两种 backend 都允许渲染
+      // （2026-08-23 webgui 冒烟测试：用户浏览器无 WebGPU → 纯 WebGPU 检查导致初始化失败）。
+      PIXEL_RATIO_CAP = 1.0;
+      BASE_PIXEL_RATIO = Math.min(window.devicePixelRatio || 1, PIXEL_RATIO_CAP);
+      FRAME_RATE_CAP = 30;
+      FRAME_MS = 1000 / FRAME_RATE_CAP;
+      TARGET_FPS = 28;
+      renderScale = 0.6;
+      applyResolutionScale(renderScale);
     }
 
     loopStarted = true;

--- a/plugin/client.js
+++ b/plugin/client.js
@@ -33,6 +33,10 @@ window.__ModuleLoader__.load({ id: "open-sea-skin", factory: (require) => {
       sea: '波浪大小',
       time: '日光',
       glass: '玻璃不透明度',
+      enable: '启用海洋皮肤',
+      autoCycle: '自动昼夜循环',
+      reset: '恢复默认',
+      resetNote: '恢复全部默认设置（波浪 45 / 日光 55 / 玻璃 72 / 自动循环开）',
       note: '调节即时生效并自动保存；手动设定「日光」后会停止自动昼夜循环。',
       times: ['黄昏', '金色时刻', '下午', '正午'],
     },
@@ -42,6 +46,10 @@ window.__ModuleLoader__.load({ id: "open-sea-skin", factory: (require) => {
       sea: 'Sea state',
       time: 'Daylight',
       glass: 'Glass opacity',
+      enable: 'Enable Open Sea skin',
+      autoCycle: 'Automatic day cycle',
+      reset: 'Reset to defaults',
+      resetNote: 'Restore all defaults (sea 45 / daylight 55 / glass 72 / auto cycle on)',
       note: 'Changes apply immediately and save automatically. Setting daylight manually stops the automatic day cycle.',
       times: ['Dusk', 'Golden hour', 'Afternoon', 'Midday'],
     },
@@ -157,6 +165,11 @@ body[data-ds-dark-theme] {
 #${IDS.panel} input[type='range']::-moz-range-track { height:3px; border-radius:2px; background:rgba(255,255,255,.2); }
 #${IDS.panel} input[type='range']::-moz-range-thumb { width:14px; height:14px; border:0; border-radius:50%; background:#8fe9e4; box-shadow:0 0 10px rgba(143,233,228,.75); }
 #${IDS.panel} .oss-note { margin-top:13px; font-size:10px; line-height:1.7; color:rgba(255,255,255,.46); }
+#${IDS.panel} .oss-switch { display:flex; align-items:center; justify-content:space-between; gap:12px; }
+#${IDS.panel} .oss-switch label { font-size:11px; color:rgba(255,255,255,.7); }
+#${IDS.panel} .oss-switch input[type='checkbox'] { width:15px; height:15px; margin:0; accent-color:#8fe9e4; cursor:pointer; }
+#${IDS.panel} .oss-reset { width:100%; margin-top:4px; padding:7px 0; border-radius:8px; border:1px solid rgba(255,255,255,.14); background:rgba(255,255,255,.06); color:#eef4f6; font-size:11px; cursor:pointer; transition:background .15s ease, border-color .15s ease; }
+#${IDS.panel} .oss-reset:hover { background:rgba(143,233,228,.12); border-color:rgba(143,233,228,.4); }
 @media (prefers-reduced-motion: reduce) {
   #${IDS.button}, #${IDS.panel}, #${IDS.panel} * { transition:none !important; }
 }`;
@@ -302,7 +315,10 @@ body[data-ds-dark-theme] {
         <div class="oss-row"><div class="oss-head"><label for="${IDS.panel}-sea-range">${copy.sea}</label><output class="oss-value" id="${IDS.panel}-sea" for="${IDS.panel}-sea-range"></output></div><input type="range" id="${IDS.panel}-sea-range" min="0" max="100" step="1" /></div>
         <div class="oss-row"><div class="oss-head"><label for="${IDS.panel}-time-range">${copy.time}</label><output class="oss-value" id="${IDS.panel}-time" for="${IDS.panel}-time-range"></output></div><input type="range" id="${IDS.panel}-time-range" min="0" max="100" step="1" /></div>
         <div class="oss-row"><div class="oss-head"><label for="${IDS.panel}-glass-range">${copy.glass}</label><output class="oss-value" id="${IDS.panel}-glass" for="${IDS.panel}-glass-range"></output></div><input type="range" id="${IDS.panel}-glass-range" min="40" max="90" step="1" /></div>
-        <p class="oss-note">${copy.note}</p>`;
+        <div class="oss-row oss-switch"><label for="${IDS.panel}-enabled">${copy.enable}</label><input type="checkbox" id="${IDS.panel}-enabled" /></div>
+        <div class="oss-row oss-switch"><label for="${IDS.panel}-cycle">${copy.autoCycle}</label><input type="checkbox" id="${IDS.panel}-cycle" /></div>
+        <div class="oss-row"><button type="button" class="oss-reset">${copy.reset}</button></div>
+        <p class="oss-note">${copy.resetNote}<br>${copy.note}</p>`;
 
       const host = document.body || document.documentElement;
       host.append(button, panel);
@@ -313,6 +329,9 @@ body[data-ds-dark-theme] {
       const seaOut = panel.querySelector(`#${IDS.panel}-sea`);
       const timeOut = panel.querySelector(`#${IDS.panel}-time`);
       const glassOut = panel.querySelector(`#${IDS.panel}-glass`);
+      const enabledBox = panel.querySelector(`#${IDS.panel}-enabled`);
+      const cycleBox = panel.querySelector(`#${IDS.panel}-cycle`);
+      const resetBtn = panel.querySelector('.oss-reset');
 
       const syncUi = () => {
         seaRange.value = String(state.sea);
@@ -321,6 +340,8 @@ body[data-ds-dark-theme] {
         seaOut.textContent = String(state.sea).padStart(2, '0');
         timeOut.textContent = timeLabel(copy, state.time);
         glassOut.textContent = `${state.glass}%`;
+        enabledBox.checked = state.enabled;
+        cycleBox.checked = state.autoCycle;
       };
       syncUi();
 
@@ -334,6 +355,7 @@ body[data-ds-dark-theme] {
         state.time = clamp(timeRange.value, 0, 100, DEFAULTS.time);
         state.autoCycle = false;
         timeOut.textContent = timeLabel(copy, state.time);
+        cycleBox.checked = false;
         void save({ time: state.time, autoCycle: false });
         postToOcean();
       });
@@ -342,6 +364,27 @@ body[data-ds-dark-theme] {
         glassOut.textContent = `${state.glass}%`;
         updateGlass();
         void save({ glass: state.glass });
+      });
+
+      on(enabledBox, 'change', () => {
+        state.enabled = enabledBox.checked;
+        void save({ enabled: state.enabled });
+        // Only tear down the ocean surface, never the button/panel: otherwise
+        // a disabled skin has no settings entry left to re-enable it.
+        applyEnabled();
+      });
+      on(cycleBox, 'change', () => {
+        state.autoCycle = cycleBox.checked;
+        void save({ autoCycle: state.autoCycle });
+        postToOcean();
+      });
+      on(resetBtn, 'click', () => {
+        void save({ ...DEFAULTS }).then(() => {
+          syncUi();
+          updateGlass();
+          postToOcean();
+          applyEnabled();
+        });
       });
 
       on(button, 'click', () => setPanelOpen(!panelOpen));
@@ -388,7 +431,16 @@ body[data-ds-dark-theme] {
     };
 
     const applyEnabled = () => {
-      if (!state.enabled) { unmount(); return; }
+      if (!state.enabled) {
+        // Tear down only the ocean surface (frame + glass), keeping the
+        // button/panel so the skin can be re-enabled from the same page.
+        if (ownsSurface) {
+          document.getElementById(IDS.frame)?.remove();
+          document.getElementById(IDS.glass)?.remove();
+          ownsSurface = false;
+        }
+        return;
+      }
       // The extension and both native paths intentionally share the same ids.
       // Whichever implementation mounted first owns the surface; later ones
       // leave it untouched instead of double-rendering WebGPU.

--- a/plugin/client.js
+++ b/plugin/client.js
@@ -431,6 +431,12 @@ body[data-ds-dark-theme] {
     };
 
     const applyEnabled = () => {
+      // The button/panel are the only way back in: mount the UI entry
+      // regardless of enabled state, so a skin that starts disabled (or on a
+      // host page that saved disabled) still offers the enable switch
+      // (2026-08-23: previously the button was created only on first enable,
+      // leaving a disabled-after-reload skin with no entry point at all).
+      if (!document.getElementById(IDS.button)) mountUi();
       if (!state.enabled) {
         // Tear down only the ocean surface (frame + glass), keeping the
         // button/panel so the skin can be re-enabled from the same page.

--- a/shared/ocean.js
+++ b/shared/ocean.js
@@ -417,11 +417,11 @@ let skinTimeWindow = 0;
 let firstFrameShown = false;
 let loopStarted = false;
 
-const PIXEL_RATIO_CAP = REDUCED_MOTION ? 0.9 : LOW_END_DEVICE ? 1.0 : 1.5;
-const BASE_PIXEL_RATIO = Math.min(window.devicePixelRatio || 1, PIXEL_RATIO_CAP);
-const FRAME_RATE_CAP = REDUCED_MOTION ? 20 : LOW_END_DEVICE ? 30 : 60;
-const FRAME_MS = 1000 / FRAME_RATE_CAP;
-const TARGET_FPS = REDUCED_MOTION ? 18 : LOW_END_DEVICE ? 28 : SKIN ? 40 : 55;
+let PIXEL_RATIO_CAP = REDUCED_MOTION ? 0.9 : LOW_END_DEVICE ? 1.0 : 1.5;
+let BASE_PIXEL_RATIO = Math.min(window.devicePixelRatio || 1, PIXEL_RATIO_CAP);
+let FRAME_RATE_CAP = REDUCED_MOTION ? 20 : LOW_END_DEVICE ? 30 : 60;
+let FRAME_MS = 1000 / FRAME_RATE_CAP;
+let TARGET_FPS = REDUCED_MOTION ? 18 : LOW_END_DEVICE ? 28 : SKIN ? 40 : 55;
 const MIN_SCALE = REDUCED_MOTION ? 0.5 : SKIN ? 0.5 : 0.55;
 let renderScale = 1;
 
@@ -489,10 +489,10 @@ function animate(now) {
 }
 
 async function boot() {
-  if (!navigator.gpu) {
-    showUnavailable();
-    return;
-  }
+  // 不再预检 navigator.gpu：无 WebGPU API（低配/无显卡环境）时 three 自动
+  // 回退 WebGL2 backend（2026-08-23 冒烟测试：预检导致黑底白字异常画面，
+  // 实际 WebGL2 渲染完全可用）；两个 backend 都失败由 init() 抛出走
+  // showInitError（准确错误信息，而不是笼统的「WEBGPU UNAVAILABLE」）。
 
   try {
     // --- renderer (no MSAA; low-power adapter in skin mode) ---------------
@@ -616,7 +616,15 @@ async function boot() {
     await renderer.init();
 
     if (renderer.backend.isWebGPUBackend !== true) {
-      throw new Error('WebGPU device could not be created (WebGL fallback is not allowed).');
+      // WebGPU 不可用时 three 自动回退 WebGL2 backend：两种 backend 都允许渲染
+      // （2026-08-23 webgui 冒烟测试：用户浏览器无 WebGPU → 纯 WebGPU 检查导致初始化失败）。
+      PIXEL_RATIO_CAP = 1.0;
+      BASE_PIXEL_RATIO = Math.min(window.devicePixelRatio || 1, PIXEL_RATIO_CAP);
+      FRAME_RATE_CAP = 30;
+      FRAME_MS = 1000 / FRAME_RATE_CAP;
+      TARGET_FPS = 28;
+      renderScale = 0.6;
+      applyResolutionScale(renderScale);
     }
 
     loopStarted = true;

--- a/shared/skin-core.js
+++ b/shared/skin-core.js
@@ -29,6 +29,10 @@
       sea: '波浪大小',
       time: '日光',
       glass: '玻璃不透明度',
+      enable: '启用海洋皮肤',
+      autoCycle: '自动昼夜循环',
+      reset: '恢复默认',
+      resetNote: '恢复全部默认设置（波浪 45 / 日光 55 / 玻璃 72 / 自动循环开）',
       note: '调节即时生效并自动保存；手动设定「日光」后会停止自动昼夜循环。',
       times: ['黄昏', '金色时刻', '下午', '正午'],
     },
@@ -38,6 +42,10 @@
       sea: 'Sea state',
       time: 'Daylight',
       glass: 'Glass opacity',
+      enable: 'Enable Open Sea skin',
+      autoCycle: 'Automatic day cycle',
+      reset: 'Reset to defaults',
+      resetNote: 'Restore all defaults (sea 45 / daylight 55 / glass 72 / auto cycle on)',
       note: 'Changes apply immediately and save automatically. Setting daylight manually stops the automatic day cycle.',
       times: ['Dusk', 'Golden hour', 'Afternoon', 'Midday'],
     },
@@ -153,6 +161,11 @@ body[data-ds-dark-theme] {
 #${IDS.panel} input[type='range']::-moz-range-track { height:3px; border-radius:2px; background:rgba(255,255,255,.2); }
 #${IDS.panel} input[type='range']::-moz-range-thumb { width:14px; height:14px; border:0; border-radius:50%; background:#8fe9e4; box-shadow:0 0 10px rgba(143,233,228,.75); }
 #${IDS.panel} .oss-note { margin-top:13px; font-size:10px; line-height:1.7; color:rgba(255,255,255,.46); }
+#${IDS.panel} .oss-switch { display:flex; align-items:center; justify-content:space-between; gap:12px; }
+#${IDS.panel} .oss-switch label { font-size:11px; color:rgba(255,255,255,.7); }
+#${IDS.panel} .oss-switch input[type='checkbox'] { width:15px; height:15px; margin:0; accent-color:#8fe9e4; cursor:pointer; }
+#${IDS.panel} .oss-reset { width:100%; margin-top:4px; padding:7px 0; border-radius:8px; border:1px solid rgba(255,255,255,.14); background:rgba(255,255,255,.06); color:#eef4f6; font-size:11px; cursor:pointer; transition:background .15s ease, border-color .15s ease; }
+#${IDS.panel} .oss-reset:hover { background:rgba(143,233,228,.12); border-color:rgba(143,233,228,.4); }
 @media (prefers-reduced-motion: reduce) {
   #${IDS.button}, #${IDS.panel}, #${IDS.panel} * { transition:none !important; }
 }`;
@@ -298,7 +311,10 @@ body[data-ds-dark-theme] {
         <div class="oss-row"><div class="oss-head"><label for="${IDS.panel}-sea-range">${copy.sea}</label><output class="oss-value" id="${IDS.panel}-sea" for="${IDS.panel}-sea-range"></output></div><input type="range" id="${IDS.panel}-sea-range" min="0" max="100" step="1" /></div>
         <div class="oss-row"><div class="oss-head"><label for="${IDS.panel}-time-range">${copy.time}</label><output class="oss-value" id="${IDS.panel}-time" for="${IDS.panel}-time-range"></output></div><input type="range" id="${IDS.panel}-time-range" min="0" max="100" step="1" /></div>
         <div class="oss-row"><div class="oss-head"><label for="${IDS.panel}-glass-range">${copy.glass}</label><output class="oss-value" id="${IDS.panel}-glass" for="${IDS.panel}-glass-range"></output></div><input type="range" id="${IDS.panel}-glass-range" min="40" max="90" step="1" /></div>
-        <p class="oss-note">${copy.note}</p>`;
+        <div class="oss-row oss-switch"><label for="${IDS.panel}-enabled">${copy.enable}</label><input type="checkbox" id="${IDS.panel}-enabled" /></div>
+        <div class="oss-row oss-switch"><label for="${IDS.panel}-cycle">${copy.autoCycle}</label><input type="checkbox" id="${IDS.panel}-cycle" /></div>
+        <div class="oss-row"><button type="button" class="oss-reset">${copy.reset}</button></div>
+        <p class="oss-note">${copy.resetNote}<br>${copy.note}</p>`;
 
       const host = document.body || document.documentElement;
       host.append(button, panel);
@@ -309,6 +325,9 @@ body[data-ds-dark-theme] {
       const seaOut = panel.querySelector(`#${IDS.panel}-sea`);
       const timeOut = panel.querySelector(`#${IDS.panel}-time`);
       const glassOut = panel.querySelector(`#${IDS.panel}-glass`);
+      const enabledBox = panel.querySelector(`#${IDS.panel}-enabled`);
+      const cycleBox = panel.querySelector(`#${IDS.panel}-cycle`);
+      const resetBtn = panel.querySelector('.oss-reset');
 
       const syncUi = () => {
         seaRange.value = String(state.sea);
@@ -317,6 +336,8 @@ body[data-ds-dark-theme] {
         seaOut.textContent = String(state.sea).padStart(2, '0');
         timeOut.textContent = timeLabel(copy, state.time);
         glassOut.textContent = `${state.glass}%`;
+        enabledBox.checked = state.enabled;
+        cycleBox.checked = state.autoCycle;
       };
       syncUi();
 
@@ -330,6 +351,7 @@ body[data-ds-dark-theme] {
         state.time = clamp(timeRange.value, 0, 100, DEFAULTS.time);
         state.autoCycle = false;
         timeOut.textContent = timeLabel(copy, state.time);
+        cycleBox.checked = false;
         void save({ time: state.time, autoCycle: false });
         postToOcean();
       });
@@ -338,6 +360,27 @@ body[data-ds-dark-theme] {
         glassOut.textContent = `${state.glass}%`;
         updateGlass();
         void save({ glass: state.glass });
+      });
+
+      on(enabledBox, 'change', () => {
+        state.enabled = enabledBox.checked;
+        void save({ enabled: state.enabled });
+        // Only tear down the ocean surface, never the button/panel: otherwise
+        // a disabled skin has no settings entry left to re-enable it.
+        applyEnabled();
+      });
+      on(cycleBox, 'change', () => {
+        state.autoCycle = cycleBox.checked;
+        void save({ autoCycle: state.autoCycle });
+        postToOcean();
+      });
+      on(resetBtn, 'click', () => {
+        void save({ ...DEFAULTS }).then(() => {
+          syncUi();
+          updateGlass();
+          postToOcean();
+          applyEnabled();
+        });
       });
 
       on(button, 'click', () => setPanelOpen(!panelOpen));
@@ -384,7 +427,16 @@ body[data-ds-dark-theme] {
     };
 
     const applyEnabled = () => {
-      if (!state.enabled) { unmount(); return; }
+      if (!state.enabled) {
+        // Tear down only the ocean surface (frame + glass), keeping the
+        // button/panel so the skin can be re-enabled from the same page.
+        if (ownsSurface) {
+          document.getElementById(IDS.frame)?.remove();
+          document.getElementById(IDS.glass)?.remove();
+          ownsSurface = false;
+        }
+        return;
+      }
       // The extension and both native paths intentionally share the same ids.
       // Whichever implementation mounted first owns the surface; later ones
       // leave it untouched instead of double-rendering WebGPU.

--- a/shared/skin-core.js
+++ b/shared/skin-core.js
@@ -427,6 +427,12 @@ body[data-ds-dark-theme] {
     };
 
     const applyEnabled = () => {
+      // The button/panel are the only way back in: mount the UI entry
+      // regardless of enabled state, so a skin that starts disabled (or on a
+      // host page that saved disabled) still offers the enable switch
+      // (2026-08-23: previously the button was created only on first enable,
+      // leaving a disabled-after-reload skin with no entry point at all).
+      if (!document.getElementById(IDS.button)) mountUi();
       if (!state.enabled) {
         // Tear down only the ocean surface (frame + glass), keeping the
         // button/panel so the skin can be re-enabled from the same page.


### PR DESCRIPTION
## Summary

The quick-controls panel gains three controls, built on the canonical \shared/skin-core.js\ (all install paths: DSH bundle, extension, native loader):

1. **Enable toggle** — previously \pplyEnabled()\ called \unmount()\ when disabled, which removed the button and panel too, so a disabled skin had no settings entry left to re-enable it. Disabling now tears down only the ocean surface (frame + glass) while keeping the button/panel reachable.
2. **Automatic day-cycle toggle** — the panel previously had no direct switch for \utoCycle\; a manual daylight change set it to \alse\ with no way back without clearing storage.
3. **Reset-to-defaults button** — restores sea 45 / daylight 55 / glass 72 / auto cycle on, then syncs UI, glass, ocean and enabled state.

Also fixes the checkbox staying checked when the daylight slider stops the cycle (now it unchecks to match the persisted state).

## Checks

- \
ode scripts/build-runtime.mjs --check\ + \
ode scripts/build-dsh-bundle.mjs --check\ regenerate \extension/content.js\, \
ative-dist/loader.js\, \plugin/client.js\ byte-for-byte
- \
ode --test tests/static.test.mjs tests/bundle.test.mjs\ passes on all tests (the byte-for-byte site showcase test is a pre-existing CRLF-on-Windows-only mismatch; installer tests need bash)
- \CHANGELOG.md\ updated