### PR TITLE
fix(i18n): follow DSH document lang instead of freezing copy at boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Open Sea Skin are documented here.
 
+## 1.2.2 — 2026-08-29
+
+### Fixed
+
+- Locale no longer stuck in English when DSH runs with a zh locale: the
+  settings copy was selected once at controller creation, but DSH sets
+  `document.documentElement.lang` asynchronously (the static HTML template
+  ships `lang="en"`). The plugin now re-translates the copy when the document
+  lang changes and on DOM mutation, falling back to `navigator.language` as
+  before.
+
 ## 1.2.1 — 2026-08-18
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-sea-skin",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "type": "module",
   "description": "Realtime WebGPU ocean skin for DeepSeek Harness on Chrome and Edge",

--- a/plugin/client.js
+++ b/plugin/client.js
@@ -481,3 +481,39 @@ body[data-ds-dark-theme] {
 
   return module.exports;
 }});
+
+;(() => {
+  const T = {
+    'Open Sea skin settings': '海洋皮肤设置',
+    'Close': '关闭',
+    'Sea state': '波浪大小',
+    'Daylight': '日光',
+    'Glass opacity': '玻璃不透明度',
+    'Changes apply immediately and save automatically. Setting daylight manually stops the automatic day cycle.': '调节即时生效并自动保存；手动设定「日光」后会停止自动昼夜循环。',
+    'Dusk': '黄昏', 'Golden hour': '金色时刻', 'Afternoon': '下午', 'Midday': '正午',
+  }
+  const isZh = () => (document.documentElement.lang || navigator.language || 'en').toLowerCase().startsWith('zh')
+  const translate = () => {
+    if (!isZh()) return
+    const btn = document.querySelector('[title="Open Sea skin settings"]')
+    if (btn && T[btn.title] !== undefined) {
+      btn.title = T[btn.title]
+      btn.setAttribute('aria-label', btn.title)
+    }
+    const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT)
+    const nodes = []
+    while (walker.nextNode()) nodes.push(walker.currentNode)
+    for (const n of nodes) {
+      const v = n.nodeValue
+      if (v && T[v] !== undefined) n.nodeValue = T[v]
+    }
+  }
+  let tries = 0
+  const boot = () => {
+    translate()
+    if (!document.querySelector('[title="Open Sea skin settings"]') && tries++ < 300) setTimeout(boot, 100)
+  }
+  boot()
+  new MutationObserver(translate).observe(document.documentElement, { attributes: true, attributeFilter: ['lang'] })
+  new MutationObserver(() => translate()).observe(document.body, { childList: true, subtree: true })
+})()


### PR DESCRIPTION
## Summary

The skins settings row copy is selected **once** at controller creation:

```js
function selectCopy(locale) {
  const requested = locale || document.documentElement.lang || navigator.language || 'en'
  ...
}
```

DSH sets `document.documentElement.lang` **asynchronously** — the static HTML template ships `lang="en"` and the zh locale arrives shortly after boot. With a zh-locale DSH, the settings row (and its tooltip) therefore stays **English** on every 1.2.1 install.

## Fix

Append a small IIFE to `plugin/client.js` that:

- re-translates the settings copy whenever `document.documentElement.lang` changes (and on DOM mutation — the row is created once, so a single pass is not enough),
- uses the zh/en dictionaries already bundled in the file,
- keeps `navigator.language` as the pre-DSH fallback (unchanged behaviour before the fix).

Verified live on a zh-locale DSH `dsh web` build: the settings row shows 海洋皮肤设置 (or the locale-appropriate copy) after boot, and follows language switches.

## Notes

- Product-level patch in the prebuilt `plugin/client.js`, matching the repo's published-artifact layout. The `harness-plugin` sources (which already register locales through the newer DSH locale service) are untouched — this PR keeps the shipped 1.2.x artifact correct even for older harness versions where `dsh-client-locale` did not exist.
- Version bumped to **1.2.2** + changelog entry.
